### PR TITLE
Actually make use of packs cache

### DIFF
--- a/src/FileSystem-Git.package/GitRepository.class/instance/packs.st
+++ b/src/FileSystem-Git.package/GitRepository.class/instance/packs.st
@@ -1,7 +1,8 @@
 accessing-packs
 packs
-	packs := OrderedCollection new.
-	self packsDir files 
-		reject: [ :file | file basename endsWith: '.idx' ]
-		thenDo: [ :packfile | packs add: (GitPackFile on: packfile in: self) ].
-	^ packs
+	^ packs ifNil: [
+		packs := OrderedCollection new.
+		self packsDir files 
+			reject: [ :file | file basename endsWith: '.idx' ]
+			thenDo: [ :packfile | packs add: (GitPackFile on: packfile in: self) ].
+		packs]


### PR DESCRIPTION
This lets the object list load much faster.
There already was the instance variable. But even when it was set, packs were recalculated every time.